### PR TITLE
Fixed version errors upon start-up.

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,6 +6,10 @@ import fire
 import signal
 import sys
 from os import path
+#Check version.
+import gi
+gi.require_version('Gtk', '3.0')
+gi.require_version('AppIndicator3', '0.1')
 from gi.repository import Gtk as gtk
 from gi.repository import GObject
 from gi.repository import AppIndicator3 as appindicator


### PR DESCRIPTION
As outlined in errors, checked for `Gtk` and `AppIndicator3` versions upon startup.